### PR TITLE
Encoding of file paths

### DIFF
--- a/classes/OpenGraph.php
+++ b/classes/OpenGraph.php
@@ -107,7 +107,7 @@ class OpenGraph3 extends \Frontend {
                             $objFile = FilesModel::findByUuid( $value );
 
                             if( $objFile ) {
-                                $value = Environment::get('base') . $objFile->path;
+                                $value = Environment::get('base') . System::urlEncode($objFile->path);
                             } else {
                                 continue 2;
                             }


### PR DESCRIPTION
When using images with special chars in their filename/path the Facebook debugger does not accept the image, so the generated url should be url encoded.