### PR TITLE
Update tl_page.php

### DIFF
--- a/dca/tl_page.php
+++ b/dca/tl_page.php
@@ -31,6 +31,14 @@ if (version_compare(VERSION, '4.9', '>='))
     ,   $GLOBALS['TL_DCA']['tl_page']['palettes']['rootfallback']
     );
 }
+if (version_compare(VERSION, '4.10', '>='))
+{
+    $GLOBALS['TL_DCA']['tl_page']['palettes']['rootfallback'] = str_replace(
+        '{protected_legend'
+    ,   $GLOBALS['TL_DCA']['opengraph_fields']['palettes']['default'].'{protected_legend'
+    ,   $GLOBALS['TL_DCA']['tl_page']['palettes']['rootfallback']
+    );
+}
 $GLOBALS['TL_DCA']['tl_page']['palettes']['regular'] = str_replace(
     '{protected_legend'
 ,   $GLOBALS['TL_DCA']['opengraph_fields']['palettes']['default'].'{protected_legend'


### PR DESCRIPTION
Ich weiß nicht, ob es an der Version 4.10 liegt, aber ohne diesen Zusatz funktioniert es in der Version 4.10 nicht in der root-Seite.