### PR TITLE
Contao 4.9: Add opengraph for rootfallback

### DIFF
--- a/src/Resources/contao/dca/tl_page.php
+++ b/src/Resources/contao/dca/tl_page.php
@@ -27,11 +27,14 @@ if( !empty($GLOBALS['TL_DCA']['tl_page']) ) {
     ,   $GLOBALS['TL_DCA']['tl_page']['palettes']['root']
     );
     
+if (version_compare(VERSION, '4.9', '>='))
+{
     $GLOBALS['TL_DCA']['tl_page']['palettes']['rootfallback'] = str_replace(
         '{dns_legend'
     ,   $GLOBALS['TL_DCA']['opengraph_fields']['palettes']['default'].'{dns_legend'
-    ,   $GLOBALS['TL_DCA']['tl_page']['palettes']['root']
+    ,   $GLOBALS['TL_DCA']['tl_page']['palettes']['rootfallback']
     );
+}
 
     $GLOBALS['TL_DCA']['tl_page']['palettes']['regular'] = str_replace(
         '{protected_legend'

--- a/src/Resources/contao/dca/tl_page.php
+++ b/src/Resources/contao/dca/tl_page.php
@@ -26,6 +26,12 @@ if( !empty($GLOBALS['TL_DCA']['tl_page']) ) {
     ,   $GLOBALS['TL_DCA']['opengraph_fields']['palettes']['default'].'{dns_legend'
     ,   $GLOBALS['TL_DCA']['tl_page']['palettes']['root']
     );
+    
+    $GLOBALS['TL_DCA']['tl_page']['palettes']['rootfallback'] = str_replace(
+        '{dns_legend'
+    ,   $GLOBALS['TL_DCA']['opengraph_fields']['palettes']['default'].'{dns_legend'
+    ,   $GLOBALS['TL_DCA']['tl_page']['palettes']['root']
+    );
 
     $GLOBALS['TL_DCA']['tl_page']['palettes']['regular'] = str_replace(
         '{protected_legend'


### PR DESCRIPTION
As described [here] (https://github.com/contao/contao/pull/717), since Contao 4.9 you need to add your fields to the new page type `rootfallback` in order to make them appear. 

Otherwise your fields will only appear, if the language fallback checkbox isn't selected.