### PR TITLE
Extending contao events

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ By default the OpenGraph fields are attached to the site structure. Furthermore 
 
 
 * [news](https://github.com/contao/news-bundle)
+* [calendar](https://github.com/contao/calendar-bundle)
 * [isotope](https://github.com/isotope/core)
 * [storelocator](https://github.com/numero2/contao-storelocator)
 

--- a/src/Resources/contao/classes/OpenGraphCalendarEvents.php
+++ b/src/Resources/contao/classes/OpenGraphCalendarEvents.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Contao Open Source CMS
+ *
+ * Copyright (c) 2005-2021 Leo Feyer
+ *
+ * @package   Opengraph3
+ * @author    Benny Born <benny.born@numero2.de>
+ * @author    Michael Bösherz <michael.boesherz@numero2.de>
+ * @license   LGPL
+ * @copyright 2021 numero2 - Agentur für digitales Marketing GbR
+ */
+
+
+namespace numero2\OpenGraph3;
+
+use Contao\CalendarEventsModel;
+use Contao\Input;
+use Contao\StringUtil;
+
+
+class OpenGraphCalendarEvents {
+
+
+    /**
+     * Appends OpenGraph data from news articles
+     *
+     * @param $objModule
+     */
+    public static function addModuleData( $objModule ): void
+    {
+
+        $calendars = StringUtil::deserialize($objModule->cal_calendar, true);
+        $event = CalendarEventsModel::findPublishedByParentAndIdOrAlias(Input::get('events'), $calendars);
+
+        // Check if the calendar event could get loaded from the database
+        if (null === $event) {
+            return;
+        }
+
+        OpenGraph3::addProperty('og_type', 'website', $event);
+
+        OpenGraph3::addTagsToPage($event);
+    }
+}

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -28,6 +28,11 @@ $GLOBALS['TL_OG_MODULES'] = [
     ,   'numero2\OpenGraph3\OpenGraphNews'
     ]
 ,   [
+        'eventreader'
+    ,   'Contao\ModuleEventReader'
+    ,   'numero2\OpenGraph3\OpenGraphCalendarEvents'
+    ]
+,   [
         'storelocator_details'
     ,   'numero2\StoreLocator\ModuleStoreLocatorDetails'
     ,   'numero2\OpenGraph3\OpenGraphStoreLocator'

--- a/src/Resources/contao/dca/tl_calendar_events.php
+++ b/src/Resources/contao/dca/tl_calendar_events.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Contao Open Source CMS
+ *
+ * Copyright (c) 2005-2021 Leo Feyer
+ *
+ * @package   Opengraph3
+ * @author    Benny Born <benny.born@numero2.de>
+ * @author    Michael Bösherz <michael.boesherz@numero2.de>
+ * @license   LGPL
+ * @copyright 2021 numero2 - Agentur für digitales Marketing GbR
+ */
+
+
+if(!empty($GLOBALS['TL_DCA']['tl_calendar_events'])) {
+
+    \Contao\System::loadLanguageFile('opengraph_fields');
+    \Contao\Controller::loadDataContainer('opengraph_fields');
+
+    /**
+     * Modify palettes
+     */
+    $GLOBALS['TL_DCA']['tl_calendar_events']['palettes']['default'] = str_replace(
+        '{expert_legend'
+    ,   $GLOBALS['TL_DCA']['opengraph_fields']['palettes']['default'].'{expert_legend'
+    ,   $GLOBALS['TL_DCA']['tl_calendar_events']['palettes']['default']
+    );
+
+    /**
+     * Modify fields
+     */
+    $GLOBALS['TL_DCA']['tl_calendar_events']['fields'] = array_merge(
+        $GLOBALS['TL_DCA']['tl_calendar_events']['fields']
+    ,   $GLOBALS['TL_DCA']['opengraph_fields']['fields']
+    );
+
+    /**
+     * Add legends
+     */
+    array_walk(
+        $GLOBALS['TL_LANG']['opengraph_fields']['legends']
+    ,   static function( $translation, $key ) {
+            $GLOBALS['TL_LANG']['tl_calendar_events'][$key] = $translation;
+        }
+    );
+
+    /**
+     * Restrict available types
+     */
+    $GLOBALS['TL_DCA']['tl_calendar_events']['config']['allowedOpenGraphTypes'] = ['website'];
+}


### PR DESCRIPTION
This pull request add the ability to manage open graph data for the Contao calendar events.
As open graph type only the "website" is available.