### PR TITLE
Automatically add `og:image:width` and `og:image:height` tags

### DIFF
--- a/src/Resources/contao/classes/OpenGraph.php
+++ b/src/Resources/contao/classes/OpenGraph.php
@@ -124,7 +124,8 @@ class OpenGraph3 extends Frontend {
 
                                     if( $oFile && $oFile->exists() && $oFile->isGdImage ) {
                                         try {
-                                            $src = System::getContainer()->get('contao.image.image_factory')->create(TL_ROOT . '/' . $objFile->path, $size)->getUrl(TL_ROOT);
+                                            $resized = System::getContainer()->get('contao.image.image_factory')->create(TL_ROOT . '/' . $objFile->path, $size);
+                                            $src = $resized->getUrl(TL_ROOT);
 
                                             if( $src !== $objFile->path ) {
                                                 $value = Environment::get('base') . System::urlEncode($src);
@@ -149,9 +150,16 @@ class OpenGraph3 extends Frontend {
                         break;
                     }
 
-                    // add og:image:secure_url if applicable
-                    if( $tag === 'og:image' && strpos($value,'https:') !== false ) {
-                        self::addTag('og:image:secure_url', $value);
+                    // add og:image:secure_url and image size tags if applicable
+                    if( $tag === 'og:image' ) {
+                        $resizedSize = $resized->getDimensions()->getSize();
+
+                        self::addTag('og:image:width', $resizedSize->getWidth());
+                        self::addTag('og:image:height', $resizedSize->getHeight());
+
+                        if ( strpos($value,'https:') !== false ) {
+                            self::addTag('og:image:secure_url', $value);
+                        }
                     }
 
                     self::addTag($tag, $value);


### PR DESCRIPTION
This PR sets `og:image:width` and `og:image:height` tags on page automatically, if the page has `og:image` image set.

Although optional in OpenGraph specs, Facebook [recommends](https://developers.facebook.com/docs/sharing/best-practices/#images) adding `og:image:width` and `og:image:height` to improve parsing on their side. ~Moreover, without those tags, the page does not even pass validation in their [sharing debugger](https://developers.facebook.com/tools/debug)~