### PR TITLE
Remove slash

### DIFF
--- a/src/Resources/contao/classes/OpenGraph.php
+++ b/src/Resources/contao/classes/OpenGraph.php
@@ -325,7 +325,7 @@ class OpenGraph3 {
         }
 
         $GLOBALS['TL_HEAD'][] = sprintf(
-            '<meta %s="%s" content="%s" />'
+            '<meta %s="%s" content="%s">'
         ,   $attribute
         ,   $tagName
         ,   $tagValue


### PR DESCRIPTION
Because the W3C Validator notes:
Trailing slash on void elements has no effect and interacts badly with unquoted attribute values.

![image](https://user-images.githubusercontent.com/8830861/199225315-eb1f9f97-130b-4391-a9f9-54fb25354cfa.png)
