### PR TITLE
Add missing import

### DIFF
--- a/src/Resources/contao/classes/OpenGraph.php
+++ b/src/Resources/contao/classes/OpenGraph.php
@@ -22,6 +22,7 @@ use Contao\Environment;
 use Contao\File;
 use Contao\FilesModel;
 use Contao\InsertTags;
+use Contao\Model;
 use Contao\ModuleModel;
 use Contao\PageModel;
 use Contao\StringUtil;

--- a/src/Resources/contao/classes/OpenGraph.php
+++ b/src/Resources/contao/classes/OpenGraph.php
@@ -208,7 +208,7 @@ class OpenGraph3 {
      *
      * @param string $prop
      * @param string $value
-     * @param Model $objRef
+     * @param mixed $objRef
      */
     public static function addProperty( $prop, $value, $objRef ): void {
 
@@ -224,7 +224,7 @@ class OpenGraph3 {
     /**
      * Appends OpenGraph data for the given module
      *
-     * @param Model $objRow
+     * @param mixed $objRow
      * @param String $strBuffer
      * @param Module $objModule
      *
@@ -251,7 +251,7 @@ class OpenGraph3 {
      * Checks if the given Content Element is a module and tries to use it
      * for OpenGraph data
      *
-     * @param Model $objRow
+     * @param mixed $objRow
      * @param String $strBuffer
      * @param Contao\ContentElement $objElement
      *


### PR DESCRIPTION
My IntelliSense complains that instance of `numero2\OpenGraph3\Model` is expected as 3rd argument to `OpenGraph3::addproperty()`, but this class does not exist. It comes from PHPDoc declaration here:

https://github.com/numero2/contao-opengraph3/blob/808c6309099548b5d2967731101476f1148838b3/src/Resources/contao/classes/OpenGraph.php#L205-L212

I assume, `Contao\Model` was meant here?